### PR TITLE
feat(onebot): caching metadata

### DIFF
--- a/avilla/onebot/v11/perform/action/scene.py
+++ b/avilla/onebot/v11/perform/action/scene.py
@@ -97,7 +97,7 @@ class OneBot11BanActionPerform((m := AccountCollector["OneBot11Protocol", "OneBo
         if raw := await cache.get(f"onebot11/account({self.account.route['account']}).stranger({target['stranger']})"):
             return Nick(raw["nickname"], raw["nickname"], None)
         result = await self.account.connection.call(
-            "get_stranger_info ", {"user_id": int(target["stranger"]), "no_cache": True}
+            "get_stranger_info", {"user_id": int(target["stranger"]), "no_cache": True}
         )
         if result is None:
             raise RuntimeError(f"Failed to get stranger {target}")
@@ -153,7 +153,7 @@ class OneBot11BanActionPerform((m := AccountCollector["OneBot11Protocol", "OneBo
         if raw := await cache.get(f"onebot11/account({self.account.route['account']}).stranger({target['stranger']})"):
             return Summary(raw["nickname"], None)
         result = await self.account.connection.call(
-            "get_stranger_info ", {"user_id": int(target["stranger"]), "no_cache": True}
+            "get_stranger_info", {"user_id": int(target["stranger"]), "no_cache": True}
         )
         if result is None:
             raise RuntimeError(f"Failed to get stranger {target}")

--- a/avilla/onebot/v11/perform/action/scene.py
+++ b/avilla/onebot/v11/perform/action/scene.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from datetime import timedelta
 from typing import TYPE_CHECKING
+
+from graia.amnesia.builtins.memcache import Memcache, MemcacheService
 
 from avilla.core.ryanvk.collector.account import AccountCollector
 from avilla.core.selector import Selector
@@ -48,32 +49,73 @@ class OneBot11BanActionPerform((m := AccountCollector["OneBot11Protocol", "OneBo
 
     @m.pull("land.group.member", Nick)
     async def get_member_nick(self, target: Selector, route: ...) -> Nick:
+        cache: Memcache = self.protocol.avilla.launch_manager.get_component(MemcacheService).cache
+        if raw := await cache.get(
+            f"onebot11/account({self.account.route['account']}).group({target['group']}).member({target['member']})"
+        ):
+            return Nick(raw.get("card", "") or raw["nickname"], raw["nickname"], raw.get("title"))
         result = await self.account.connection.call(
-            "get_group_member_info", {"group_id": int(target["group"]), "user_id": int(target["member"])}
+            "get_group_member_info",
+            {"group_id": int(target["group"]), "user_id": int(target["member"]), "no_cache": True},
         )
         if result is None:
             raise RuntimeError(f"Failed to get member {target}")
         return Nick(result.get("card", "") or result["nickname"], result["nickname"], result.get("title"))
 
     @m.pull("land.friend", Nick)
+    async def get_friend_nick(self, target: Selector, route: ...) -> Nick:
+        cache: Memcache = self.protocol.avilla.launch_manager.get_component(MemcacheService).cache
+        if raw := await cache.get(f"onebot11/account({self.account.route['account']}).friend({target['friend']})"):
+            return Nick(raw["nickname"], raw.get("remark") or raw["nickname"], None)
+        if not (results := await self.account.connection.call("get_friend_list")):
+            raise RuntimeError(f"Failed to get friend {target}")
+        if not (result := next(filter(lambda x: x["user_id"] == int(target["friend"]), results), None)):
+            raise RuntimeError(f"Failed to get friend {target}")
+        return Nick(result["nickname"], result.get("remark") or result["nickname"], None)
+
     @m.pull("land.stranger", Nick)
-    async def get_user_nick(self, target: Selector, route: ...) -> Nick:
-        result = await self.account.connection.call("get_stranger_info ", {"user_id": int(target.last_value)})
+    async def get_stranger_nick(self, target: Selector, route: ...) -> Nick:
+        cache: Memcache = self.protocol.avilla.launch_manager.get_component(MemcacheService).cache
+        if raw := await cache.get(f"onebot11/account({self.account.route['account']}).stranger({target['stranger']})"):
+            return Nick(raw["nickname"], raw["nickname"], None)
+        result = await self.account.connection.call(
+            "get_stranger_info ", {"user_id": int(target["stranger"]), "no_cache": True}
+        )
         if result is None:
             raise RuntimeError(f"Failed to get stranger {target}")
         return Nick(result["nickname"], result["nickname"], None)
 
     @m.pull("land.group", Summary)
     async def get_group_summary(self, target: Selector, route: ...) -> Summary:
-        result = await self.account.connection.call("get_group_info", {"group_id": int(target["group"])})
+        cache: Memcache = self.protocol.avilla.launch_manager.get_component(MemcacheService).cache
+        if raw := await cache.get(f"onebot11/account({self.account.route['account']}).group({target['group']})"):
+            return Summary(raw["group_name"], None)
+        result = await self.account.connection.call(
+            "get_group_info", {"group_id": int(target["group"]), "no_cache": True}
+        )
         if result is None:
             raise RuntimeError(f"Failed to get group {target}")
         return Summary(result["group_name"], None)
 
     @m.pull("land.friend", Summary)
+    async def get_friend_summary(self, target: Selector, route: ...) -> Summary:
+        cache: Memcache = self.protocol.avilla.launch_manager.get_component(MemcacheService).cache
+        if raw := await cache.get(f"onebot11/account({self.account.route['account']}).friend({target['friend']})"):
+            return Summary(raw["nickname"], "a friend contact assigned to this account")
+        if not (results := await self.account.connection.call("get_friend_list")):
+            raise RuntimeError(f"Failed to get friend {target}")
+        if not (result := next(filter(lambda x: x["user_id"] == int(target["friend"]), results), None)):
+            raise RuntimeError(f"Failed to get friend {target}")
+        return Summary(result["nickname"], "a friend contact assigned to this account")
+
     @m.pull("land.stranger", Summary)
-    async def get_user_summary(self, target: Selector, route: ...) -> Summary:
-        result = await self.account.connection.call("get_stranger_info ", {"user_id": int(target.last_value)})
+    async def get_stranger_summary(self, target: Selector, route: ...) -> Summary:
+        cache: Memcache = self.protocol.avilla.launch_manager.get_component(MemcacheService).cache
+        if raw := await cache.get(f"onebot11/account({self.account.route['account']}).stranger({target['stranger']})"):
+            return Summary(raw["nickname"], None)
+        result = await self.account.connection.call(
+            "get_stranger_info ", {"user_id": int(target["stranger"]), "no_cache": True}
+        )
         if result is None:
             raise RuntimeError(f"Failed to get stranger {target}")
         return Summary(result["nickname"], None)
@@ -86,4 +128,4 @@ class OneBot11BanActionPerform((m := AccountCollector["OneBot11Protocol", "OneBo
 
     @m.pull("land.group", Avatar)
     async def get_group_avatar(self, target: Selector, route: ...) -> Avatar:
-        return Avatar(f"https://p.qlogo.cn/gh/{target.pattern['group']}/{target.pattern['group']}/")
+        return Avatar(f"https://p.qlogo.cn/gh/{target['group']}/{target['group']}/")

--- a/test-onebot11.py
+++ b/test-onebot11.py
@@ -20,7 +20,7 @@ avilla.apply_protocols(OneBot11Protocol().configure(config))
 
 @avilla.listen(MessageReceived)
 async def on_message_received(ctx: Context):
-    nick: Nick = await ctx.pull(Nick, ctx.client)
+    nick: Nick = await ctx.pull(Nick, Selector(ctx.client.pattern))
     summary: Summary = await ctx.pull(Summary, ctx.scene)
     stranger_nick: Nick = await ctx.pull(Nick, Selector().land(ctx.land).stranger("2854196310"))  # Q群管家
     logger.success(f"{nick = }")

--- a/test-onebot11.py
+++ b/test-onebot11.py
@@ -1,18 +1,31 @@
-from avilla.core import Avilla, Context, MessageReceived
-from avilla.onebot.v11.protocol import OneBot11Protocol, OneBot11ReverseConfig
+import os
 
-from graia.amnesia.builtins.asgi import UvicornASGIService
+from loguru import logger
+from yarl import URL
+
+from avilla.core import Avilla, Context, MessageReceived, Selector
+from avilla.onebot.v11.protocol import OneBot11ForwardConfig, OneBot11Protocol
+from avilla.standard.core.profile import Nick, Summary
 
 avilla = Avilla()
 
 
-config = OneBot11ReverseConfig(endpoint="ws", access_token="dfawdfafergergeaar")
+# config = OneBot11ReverseConfig(endpoint="ws", access_token="dfawdfafergergeaar")
+config = OneBot11ForwardConfig(
+    endpoint=URL(os.environ["ONEBOT11_ENDPOINT"]), access_token=os.environ["ONEBOT11_ACCESS_TOKEN"]
+)
 avilla.apply_protocols(OneBot11Protocol().configure(config))
-avilla.launch_manager.add_component(UvicornASGIService("127.0.0.1", 9555))
+# avilla.launch_manager.add_component(UvicornASGIService("127.0.0.1", 9555))
 
 
 @avilla.listen(MessageReceived)
-async def on_message_received(ctx: Context, event: MessageReceived):
-    await ctx.scene.send_message("Hello, Avilla!")
+async def on_message_received(ctx: Context):
+    nick: Nick = await ctx.pull(Nick, ctx.client)
+    summary: Summary = await ctx.pull(Summary, ctx.scene)
+    stranger_nick: Nick = await ctx.pull(Nick, Selector().land(ctx.land).stranger("2854196310"))  # Q群管家
+    logger.success(f"{nick = }")
+    logger.success(f"{summary = }")
+    logger.success(f"{stranger_nick = }")
+
 
 avilla.launch()


### PR DESCRIPTION
Receiving: tested on [Lagrange.Onebot (aa7ca60)](https://github.com/LagrangeDev/Lagrange.Core/actions/runs/10560208193)

## Known Issue:

1. [Selector and ContextClientSelector](https://github.com/nullqwertyuiop/Avilla/blob/0d475bc807c7c20ba88efda7e498468f8c7d04dc/test-onebot11.py#L23)
    
    ```diff
    - nick: Nick = await ctx.pull(Nick, ctx.client)
    + nick: Nick = await ctx.pull(Nick, Selector(ctx.client.pattern))
    ```
    
    The type of former is `ContextClientSelector` while the type of cache keys in `context.cache` is `Selector`. When pulling, [this line](https://github.com/nullqwertyuiop/Avilla/blob/0d475bc807c7c20ba88efda7e498468f8c7d04dc/avilla/core/context/__init__.py#L133) returns `None` resulting cached metadata **not** being hit.

2. Undesired results
    
    [This line](https://github.com/nullqwertyuiop/Avilla/blob/0d475bc807c7c20ba88efda7e498468f8c7d04dc/test-onebot11.py#L23) should return a **non-empty** badge running in my environment, but in my testing it returns `""`. According to [OneBot 11 Standard Docs](https://github.com/botuniverse/onebot-11/blob/master/api/public.md#get_group_member_info-%E8%8E%B7%E5%8F%96%E7%BE%A4%E6%88%90%E5%91%98%E4%BF%A1%E6%81%AF) it should work in theory but I'm having no other capable implementations. Further tests may be needed.